### PR TITLE
DL-5364 - Failing header passing fix after 2.7 upgrade

### DIFF
--- a/app/utils/AdditionalHeaderNames.scala
+++ b/app/utils/AdditionalHeaderNames.scala
@@ -18,4 +18,5 @@ package utils
 
 object AdditionalHeaderNames {
   val CorrelationIdHeader: String = "Correlationid"
+  val Environment: String = "Environment"
 }

--- a/test/connectors/DesConnectorSpec.scala
+++ b/test/connectors/DesConnectorSpec.scala
@@ -23,7 +23,7 @@ import models.errors.{ApiServiceError, Errors}
 import models.{CalculationOutcome, CalculationRequest}
 import play.api.http.HeaderNames
 import support.data.CalculationTestData.Response.{expectedModel => validResponse}
-import utils.AdditionalHeaderNames.CorrelationIdHeader
+import utils.AdditionalHeaderNames.{CorrelationIdHeader, Environment}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -48,19 +48,19 @@ class DesConnectorSpec extends ConnectorBaseSpec {
     val correlationId = UUID.randomUUID().toString
 
     "return a header carrier with an authorization header using the DES token specified in config" in new Test {
-      connector.desHeaderCarrier(correlationId).headers(Seq(HeaderNames.AUTHORIZATION)).contains(HeaderNames.AUTHORIZATION -> "Bearer des-token") shouldBe true
+      connector.desHeaders(correlationId).contains(HeaderNames.AUTHORIZATION -> "Bearer des-token") shouldBe true
     }
 
     "return a header carrier with an Content-Type header" in new Test {
-      connector.desHeaderCarrier(correlationId).extraHeaders.contains(HeaderNames.CONTENT_TYPE -> "application/json") shouldBe true
+      connector.desHeaders(correlationId).contains(HeaderNames.CONTENT_TYPE -> "application/json") shouldBe true
     }
 
     "return a header carrier with an environment header using the DES environment specified in config" in new Test {
-      connector.desHeaderCarrier(correlationId).extraHeaders.contains("Environment" -> "des-environment") shouldBe true
+      connector.desHeaders(correlationId).contains(Environment -> "des-environment") shouldBe true
     }
 
     "return a header carrier with a CorrelationId header" in new Test {
-      connector.desHeaderCarrier(correlationId).extraHeaders.contains(CorrelationIdHeader -> correlationId) shouldBe true
+      connector.desHeaders(correlationId).contains(CorrelationIdHeader -> correlationId) shouldBe true
     }
   }
 


### PR DESCRIPTION
# DL-5364 - Failing header passing fix after 2.7 upgrade

 **Bug fix

Follow 2.7 upgrade for state-pension-calculator and state-pension-calculator-stubs the DES authorization token was not being passed in the header causing problems in production. The stubbed data was not picking up the missing header locally so stubs have been updated too to tests this.

 ## Checklist

  - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date